### PR TITLE
Implement conda recipe, and a handful of other fixes / improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ enable_testing()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 set(BUILD_SUPPORT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build-support)
 
+# Allow "make install" to not depend on all targets.
+#
+# Must be declared in the top-level CMakeLists.txt.
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
+
 if(APPLE)
   set(CMAKE_MACOSX_RPATH 1)
 endif()
@@ -57,6 +62,12 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 	"Build the libhs2client executable CLI tools"
 	ON)
 endif()
+
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)
 
 # If build in-source, create the latest symlink. If build out-of-source, which is
 # preferred, simply output the binaries in the build folder

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd $RECIPE_DIR
+
+# Build dependencies
+export BOOST_ROOT=$PREFIX
+export THRIFT_HOME=$PREFIX
+
+cd ..
+
+# Build googletest for running unit tests
+./thirdparty/download_thirdparty.sh
+./thirdparty/build_thirdparty.sh gtest
+
+source thirdparty/versions.sh
+export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
+
+if [ `uname` == Linux ]; then
+    SHARED_LINKER_FLAGS='-static-libstdc++'
+elif [ `uname` == Darwin ]; then
+    SHARED_LINKER_FLAGS=''
+fi
+
+# HACK: build in-place until we figure out out of source builds
+rm -f CMakeCache.txt
+
+cmake \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_SHARED_LINKER_FLAGS=$SHARED_LINKER_FLAGS \
+    -DHS2CLIENT_BUILD_TESTS=off \
+    .
+
+make
+make install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: libhs2client
+  version: "0.1"
+
+build:
+  number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
+  skip: true  # [win]
+  script_env:
+    - CC [linux]
+    - CXX [linux]
+    - LD_LIBRARY_PATH [linux]
+
+requirements:
+  build:
+    - cmake
+    - boost
+    - thrift-cpp
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libhs2client.so
+    - test -f $PREFIX/include/hs2client/api.h
+
+about:
+  home: http://github.com/cloudera/hs2client
+  license: Apache 2.0
+  summary: 'Libraries for the hs2client, C++ HiveServer2 Thrift client'

--- a/src/hs2client/CMakeLists.txt
+++ b/src/hs2client/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2016 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Headers: top level
+install(FILES
+  api.h
+  columnar-row-set.h
+  logging.h
+  macros.h
+  operation.h
+  service.h
+  session.h
+  status.h
+  types.h
+  util.h
+  DESTINATION include/hs2client)

--- a/src/hs2client/api.h
+++ b/src/hs2client/api.h
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef HS2CLIENT_API_H
+
 #include "hs2client/columnar-row-set.h"
-#include "hs2client/service.h"
-#include "hs2client/session.h"
 #include "hs2client/logging.h"
 #include "hs2client/macros.h"
 #include "hs2client/operation.h"
+#include "hs2client/service.h"
+#include "hs2client/session.h"
 #include "hs2client/status.h"
+#include "hs2client/types.h"
 #include "hs2client/util.h"
+
+#endif  // HS2CLIENT_API_H

--- a/src/hs2client/sample-usage.cc
+++ b/src/hs2client/sample-usage.cc
@@ -15,10 +15,7 @@
 #include <cassert>
 #include <iostream>
 
-#include "hs2client/service.h"
-#include "hs2client/session.h"
-#include "hs2client/status.h"
-#include "hs2client/util.h"
+#include "hs2client/api.h"
 
 using namespace hs2client;
 using namespace std;

--- a/thirdparty/download_thirdparty.sh
+++ b/thirdparty/download_thirdparty.sh
@@ -14,12 +14,12 @@ download_extract_and_cleanup() {
 	rm $filename
 }
 
-if [ ! -d ${GTEST_BASEDIR} ]; then
+if [ ! -d $TP_DIR/${GTEST_BASEDIR} ]; then
   echo "Fetching gtest"
   download_extract_and_cleanup $GTEST_URL
 fi
 
-if [ ! -d ${THRIFT_BASEDIR} ]; then
+if [ ! -d $TP_DIR/${THRIFT_BASEDIR} ]; then
   echo "Fetching thrift"
   download_extract_and_cleanup $THRIFT_URL
 fi


### PR DESCRIPTION
- Install headers files in `make install`
- Ensure that `make` followed by `make install` does not cause a rebuild of all
  targets
- Enable cache
- Add missing header to api.h
- Fix download_thirdparty.sh to now download redundantly when invoked from
  top-level directory
