### PR TITLE
Switch to dynamic linking.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(APPLE)
 endif()
 
 if (NOT HS2CLIENT_LINK)
-  set(HS2CLIENT_LINK "a")
+  set(HS2CLIENT_LINK "d")
 elseif(NOT ("auto" MATCHES "^${HS2CLIENT_LINK}" OR
             "dynamic" MATCHES "^${HS2CLIENT_LINK}" OR
             "static" MATCHES "^${HS2CLIENT_LINK}"))
@@ -164,11 +164,9 @@ set(LIBS ${LIBS} ${THRIFT_LIBS})
 message(STATUS "Thrift include dir: ${THRIFT_INCLUDE_DIR}")
 message(STATUS "Thrift contrib dir: ${THRIFT_CONTRIB_DIR}")
 message(STATUS "Thrift library path: ${THRIFT_LIBS}")
-message(STATUS "Thrift static library: ${THRIFT_STATIC_LIB}")
 message(STATUS "Thrift compiler: ${THRIFT_COMPILER}")
-# for static linking with Thrift, THRIFT_STATIC_LIB is set in FindThrift.cmake
-add_library(thriftstatic STATIC IMPORTED)
-set_target_properties(thriftstatic PROPERTIES IMPORTED_LOCATION ${THRIFT_STATIC_LIB})
+add_library(thrift SHARED IMPORTED)
+set_target_properties(thrift PROPERTIES IMPORTED_LOCATION ${THRIFT_LIBS})
 
 # Thrift requires these definitions for some types that we use
 add_definitions(-DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H -DHAVE_NETDB_H)
@@ -177,8 +175,8 @@ add_definitions(-fPIC)
 ## GTest
 find_package(GTest REQUIRED)
 include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
-add_library(gtest STATIC IMPORTED)
-set_target_properties(gtest PROPERTIES IMPORTED_LOCATION ${GTEST_STATIC_LIB})
+add_library(gtest SHARED IMPORTED)
+set_target_properties(gtest PROPERTIES IMPORTED_LOCATION ${GTEST_SHARED_LIB})
 
 # where to put generated archives (.a files)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")
@@ -314,7 +312,7 @@ add_library(hs2client
 
 set(LIBHS2CLIENT_LINK_LIBS
   hs2client_thrift
-  thriftstatic
+  thrift
 )
 
 add_dependencies(hs2client hs2client_thrift)

--- a/thirdparty/build_thirdparty.sh
+++ b/thirdparty/build_thirdparty.sh
@@ -50,9 +50,9 @@ if [ -n "$F_ALL" -o -n "$F_GTEST" ]; then
   cd $TP_DIR/$GTEST_BASEDIR
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    cmake -DCMAKE_CXX_FLAGS="-fPIC -std=c++11 -stdlib=libc++ -DGTEST_USE_OWN_TR1_TUPLE=1 -Wno-unused-value -Wno-ignored-attributes"
+    cmake -DCMAKE_CXX_FLAGS="-fPIC -std=c++11 -stdlib=libc++ -DGTEST_USE_OWN_TR1_TUPLE=1 -Wno-unused-value -Wno-ignored-attributes" -DBUILD_SHARED_LIBS=on
   else
-    CXXFLAGS=-fPIC cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX .
+    CXXFLAGS=-fPIC cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX -DBUILD_SHARED_LIBS=on .
   fi
 
   make

--- a/thirdparty/set_thirdparty_env.sh
+++ b/thirdparty/set_thirdparty_env.sh
@@ -13,3 +13,5 @@ if [ "$(uname)" != "Darwin" ]; then
 fi
 
 export GTEST_HOME=$THIRDPARTY_DIR/$GTEST_BASEDIR
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$THRIFT_HOME/lib


### PR DESCRIPTION
Switch cmake to shared third-party dependencies. Enable also shared build of
gtest in standalone thirdparty dependencies and add LD_LIBRARY_PATH to point
into standalone thirdparty libraries directory.

Dynamic linking is important for proper distribution, where components should not be bundled. It is even more important for libraries, where there would conflict symbols from several versions of libraries (for example static thrift in hs2client vs. dynamically linked another thrift by the software using hs2client library).