### PR TITLE
Added architecture specific condition to use -msse2 flag while building hs2client code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,17 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 
 # Build with C++11 and SSE3 by default
 # TODO(wesm): These compiler warning suppressions should be removed one by one
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -msse3 -Wall")
+
+#----------------------------
+# Settings for power arch
+#----------------------------
+EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCH )
+if (${ARCH} MATCHES "ppc64")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+else()
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -msse3 -Wall")
+endif()
+message(STATUS "ARCH: ${ARCH}")
 
 if (APPLE)
   # Use libc++ to avoid linker errors on some platforms

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,17 +223,7 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 
 # Build with C++11 and SSE3 by default
 # TODO(wesm): These compiler warning suppressions should be removed one by one
-
-#----------------------------
-# Settings for power arch
-#----------------------------
-EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCH )
-if (${ARCH} MATCHES "ppc64")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
-else()
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -msse3 -Wall")
-endif()
-message(STATUS "ARCH: ${ARCH}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 
 if (APPLE)
   # Use libc++ to avoid linker errors on some platforms


### PR DESCRIPTION
Hi ,

With reference to defect -  https://github.com/cloudera/hs2client/issues/25

As per the suggestion by @wesm in the above defect.  I have updated the code not to use SSE flag for ppc64 architectures. Updated code build successfully on ppc64le & x86 both architectures.

Thanks,
Snehlata Mohite.